### PR TITLE
Typo errors in the README.md, ampq replaced by amqp

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@ Tested with RabbitMQ under ubuntu.
 
     npm install amqp-rpc
 
-
 ###server.js example
 
-    var rpc = require('ampq-rpc').factory({
+    var rpc = require('amqp-rpc').factory({
         url: "amqp://guest:guest@localhost:5672"
     });
 
@@ -52,7 +51,7 @@ Tested with RabbitMQ under ubuntu.
 
 ###client.js example
 
-    var rpc = require('ampq-rpc').factory({
+    var rpc = require('amqp-rpc').factory({
         url: "amqp://guest:guest@localhost:5672"
     });
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         }
     ],
     "dependencies": {
-        "amqp": ">=0.1.3"
+        "amqp" : ">=0.1.3",
+        "node-uuid" : "*" 
     }
 }


### PR DESCRIPTION
I was trying to reproduce your sample code and found few typos, also I think that module node-uuid  is required in package.json .
After this small fixes the sample code worked for me. Thanks. 
