### PR TITLE
add impl options, clean up package.json and remove console.log calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ function rpc(opt)   {
     this.__exchange         = opt.exchangeInstance ? opt.exchangeInstance : null;
     this.__exchange_name    = opt.exchange ? opt.exchange : 'rpc_exchange';
     this.__exchange_options = opt.exchange_options ? opt.exchange_options : {exclusive: true, autoDelete: true };
+    this.__impl_options     = opt.ipml_options || {defaultExchangeName: this.__exchange_name};
 
     this.__results_queue = null;
     this.__results_queue_name = null;
@@ -52,13 +53,10 @@ rpc.prototype._connect = function(cb)  {
 
     this.__conn = amqp.createConnection(
         {url: this.__url},
-        {defaultExchangeName: this.__exchange_name}
+        this.__impl_options
     );
 
     this.__conn.addListener('ready', function(){
-
-//       console.log("connected to " + $this.__conn.serverProperties.product);
-
         var cbs = $this.__connCbs;
         $this.__connCbs = [];
 
@@ -101,8 +99,6 @@ rpc.prototype._makeExchange = function(cb) {
     this.__exchangeCbs.push(cb);
 
     this.__exchange = this.__conn.exchange(this.__exchange_name, {}, function(exchange)    {
-//        console.log('Exchange ' + exchange.name + ' is open');
-
         var cbs = $this.__exchangeCbs;
         $this.__exchangeCbs = [];
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     },
     "main": "./index",
     "engines": {
-        "node": "0.4 || 0.5 || 0.6 || 0.8"
+        "node": ">=0.4"
     },
     "licenses": [
         {
@@ -26,6 +26,6 @@
     ],
     "dependencies": {
         "amqp": ">=0.1.3",
-	"node-uuid": "*"
+        "node-uuid": "*"
     }
 }


### PR DESCRIPTION
This removes unnecessary console.log calls and adds the ability to have pass an impl_options object to the constructor which gets passed to node-amqp's [`createConnection()`](https://github.com/postwait/node-amqp#connection-options-and-url)
