### PR TITLE
feat: add queue options inside of 'on()'

### DIFF
--- a/index.js
+++ b/index.js
@@ -277,12 +277,13 @@ rpc.prototype.on = function(cmd, cb, context, options)    {
     debug('on(), routingKey=%s', cmd);
     if(this.__cmds[ cmd ]) return false;
     options || (options = {});
+    var qOptions = options.queueOptions || {};
 
     var $this = this;
 
     this._connect(function()    {
 
-        $this.__conn.queue(options.queueName || cmd, function(queue) {
+        $this.__conn.queue(options.queueName || cmd, qOptions, function(queue) {
             $this.__cmds[ cmd ] = { queue: queue };
             queue.subscribe(function(message, d, headers, deliveryInfo)  {
 


### PR DESCRIPTION
I needed this feature to change the parameters being passed during queue creation (`{durable: true, "autoDelete":false}`.) Example usage:

``` coffeescript
qName = key.replace ".*", "RpcQueue"
@amqpRpc.on key, (data, cb, info) =>
    # handler logic...
, null
, {queueName: qName, queueOptions: {"durable": true, "autoDelete":false}}
```
